### PR TITLE
Istio additions

### DIFF
--- a/manifests/thumbnailer.yaml
+++ b/manifests/thumbnailer.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: todolist
+  labels:
+    istio-injection: enabled
+  
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/todolist.yaml
+++ b/manifests/todolist.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: todolist
+  labels:
+    istio-injection: enabled
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Added istio injection label by default.

When the namespace is created, by default will have the necessary label for sidecar injection. 

This prevents a re-rollout of the deployment after running startup.sh and istio is already installed.
